### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.1 (2025-08-21)
+
+- chore: Updated `@apm-js-collab/code-transformer` to `v.0.7.0` to get `moduleVersion` emitted over tracing channel events
+
 ## 0.1.0 (2025-08-19) 
 
 - Added LICENSE file to the project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apm-js-collab/tracing-hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CJS and ESM hooks for orchestrion",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
Already released [here](https://www.npmjs.com/package/@apm-js-collab/tracing-hooks/v/0.1.1)