### PR TITLE
docs: Fixed markdown of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-### 0.1.1 (2025-08-21)
-
-- chore: Updated `@apm-js-collab/code-transformer` to `v.0.7.0` to get `moduleVersion` emitted over tracing channel events
-
 ## [0.2.0](https://github.com/apm-js-collab/tracing-hooks/compare/tracing-hooks-v0.1.1...tracing-hooks-v0.2.0) (2025-09-12)
 
 
@@ -13,6 +9,10 @@
 ### Bug Fixes
 
 * Remove `engines` ([#4](https://github.com/apm-js-collab/tracing-hooks/issues/4)) ([43a1847](https://github.com/apm-js-collab/tracing-hooks/commit/43a1847e6e9f4151b8a1d4899adbd304408e6165))
+
+## 0.1.1 (2025-08-21)
+
+- chore: Updated `@apm-js-collab/code-transformer` to `v.0.7.0` to get `moduleVersion` emitted over tracing channel events
 
 ## 0.1.0 (2025-08-19) 
 


### PR DESCRIPTION
0.1.1 header was h3 not h2