### PR TITLE
feat: Add optional diagnostics hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ or transformation fails. This hook will only work with the synchronous
 ```js
 import { setDiagnosticsHook } from '@apm-js-collab/tracing-hooks/hook-sync.mjs'
 
-setDiagnosticsHook(({ url, moduleName, error}) => {
+setDiagnosticsHook(({ url, moduleName, error }) => {
   if(error) {
     // injection failed
   } else {

--- a/README.md
+++ b/README.md
@@ -95,3 +95,21 @@ case, the resolved filename of the module being patched is appended. For
 example, if we are patching `lib/index.js` in the `foo` package, and we set
 a base directory of `/tmp/dump/`, then the patched code will be written to
 `/tmp/dump/foo/lib/index.js`.
+
+### Diagnostics Hook
+
+A diagnostics hook can be set which is called every time a module is transformed 
+or transformation fails. This hook will only work with the synchronous 
+`registerHooks` because the older `register` runs in a different thread.
+
+```js
+import { setDiagnosticsHook } from '@apm-js-collab/tracing-hooks/hook-sync.mjs'
+
+setDiagnosticsHook(({ url, moduleName, error}) => {
+  if(error) {
+    // injection failed
+  } else {
+    // injection succeeded
+  }
+})
+```

--- a/hook-sync.mjs
+++ b/hook-sync.mjs
@@ -1,1 +1,1 @@
-export { initializeSync as initialize, loadSync as load, resolveSync as resolve } from './hook.mjs'
+export { initializeSync as initialize, loadSync as load, resolveSync as resolve, getTransformedModules } from './hook.mjs'

--- a/hook-sync.mjs
+++ b/hook-sync.mjs
@@ -1,1 +1,1 @@
-export { initializeSync as initialize, loadSync as load, resolveSync as resolve, getTransformedModules } from './hook.mjs'
+export { initializeSync as initialize, loadSync as load, resolveSync as resolve, setDiagnosticsHook } from './hook.mjs'

--- a/hook.mjs
+++ b/hook.mjs
@@ -11,7 +11,11 @@ let transformers = null
 let packages = null
 let instrumentator = null
 
-const transformedModules = new Set()
+let diagnosticsHook;
+
+export function setDiagnosticsHook(hook) {
+  diagnosticsHook = hook
+}
 
 export async function initialize(data = {}) {
   return initializeSync(data)
@@ -81,17 +85,18 @@ export function loadResult(url, result) {
       const transformedCode = transformer.transform(code.toString('utf8'), 'unknown')
       result.source = transformedCode?.code
       result.shortCircuit = true
-      transformedModules.add(transformer.moduleName)
+      if (diagnosticsHook) {
+        diagnosticsHook(transformer.moduleName)
+      }
     } catch(err) {
       debug('Error transforming module %s: %o', url, err)
+      if (diagnosticsHook) {
+        diagnosticsHook(transformer.moduleName, err)
+      }
     } finally {
       transformer.free()
     }
   }
 
   return result
-}
-
-export function getTransformedModules() {
-  return transformedModules
 }

--- a/hook.mjs
+++ b/hook.mjs
@@ -11,6 +11,8 @@ let transformers = null
 let packages = null
 let instrumentator = null
 
+const transformedModules = new Set()
+
 export async function initialize(data = {}) {
   return initializeSync(data)
 }
@@ -79,6 +81,7 @@ export function loadResult(url, result) {
       const transformedCode = transformer.transform(code.toString('utf8'), 'unknown')
       result.source = transformedCode?.code
       result.shortCircuit = true
+      transformedModules.add(transformer.moduleName)
     } catch(err) {
       debug('Error transforming module %s: %o', url, err)
     } finally {
@@ -87,4 +90,8 @@ export function loadResult(url, result) {
   }
 
   return result
+}
+
+export function getTransformedModules() {
+  return transformedModules
 }

--- a/hook.mjs
+++ b/hook.mjs
@@ -86,12 +86,12 @@ export function loadResult(url, result) {
       result.source = transformedCode?.code
       result.shortCircuit = true
       if (diagnosticsHook) {
-        diagnosticsHook(transformer.moduleName)
+        diagnosticsHook({ url, moduleName: transformer.moduleName })
       }
     } catch(err) {
       debug('Error transforming module %s: %o', url, err)
       if (diagnosticsHook) {
-        diagnosticsHook(transformer.moduleName, err)
+        diagnosticsHook({ url, moduleName: transformer.moduleName, error: err })
       }
     } finally {
       transformer.free()

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "dependencies": {
-    "@apm-js-collab/code-transformer": "^0.13.0",
+    "@apm-js-collab/code-transformer": "^0.14.0",
     "debug": "^4.4.1",
     "module-details-from-path": "^1.0.4"
   },

--- a/test/hook-sync.test.mjs
+++ b/test/hook-sync.test.mjs
@@ -201,3 +201,25 @@ test('should default initialization to not crash if not defined', async (t) => {
   const snapshot = await snap(result.source)
   assert.deepEqual(result.source, snapshot)
 })
+
+test('should rewrite code and call diagnostics hook', async (t) => {
+  const { syncLoaderRewriter, snap } = t.ctx
+  syncLoaderRewriter.setDiagnosticsHook(({url, moduleName, error}) => {
+    assert.equal(url, `file://${esmPath}`)
+    assert.equal(moduleName, 'esm-pkg')
+    assert.equal(error, undefined)
+  })
+  const esmPath = path.join(import.meta.dirname, './example-deps/lib/node_modules/esm-pkg/foo.js')
+  function resolveFn() {
+    return { url: `file://${esmPath}` }
+  }
+  function nextLoad() {
+    const data = readFileSync(esmPath, 'utf8')
+    return {
+      format: 'module',
+      source: data
+    }
+  }
+  const url = syncLoaderRewriter.resolve('esm-pkg', {}, resolveFn)
+  syncLoaderRewriter.load(url.url, {}, nextLoad)
+})


### PR DESCRIPTION
This is dependent on this PR:
- https://github.com/nodejs/orchestrion-js/pull/74

A diagnostics hook can be set which is called every time a module is transformed 
or transformation fails. This hook will only work with the synchronous 
`registerHooks` because the older `register` hook runs in a different thread.

```js
import { setDiagnosticsHook } from '@apm-js-collab/tracing-hooks/hook-sync.mjs'

setDiagnosticsHook(({ url, moduleName, error }) => {
  if(error) {
    // injection failed
  } else {
    // injection succeeded
  }
})
```