### PR TITLE
chore: Update `@apm-js-collab/code-transformer` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "dependencies": {
-    "@apm-js-collab/code-transformer": "^0.14.0",
+    "@apm-js-collab/code-transformer": "^0.15.0",
     "debug": "^4.4.1",
     "module-details-from-path": "^1.0.4"
   },


### PR DESCRIPTION
We're using both @apm-js-collab/code-transformer-bundler-plugins and @apm-js-collab/tracing-hooks so we have ensure they're both on the same version of @apm-js-collab/code-transformer so we don't end up with two different versions. 