### PR TITLE
feat: Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## CHANGELOG
 
+
 ## [0.9.1](https://github.com/apm-js-collab/tracing-hooks/compare/tracing-hooks-v0.9.0...tracing-hooks-v0.9.1) (2026-05-29)
 
 


### PR DESCRIPTION
The description for #36 was `chore:`. Along with `build:`, `release-please` considers this not releasable. 

This PR is simply to trigger a release. When the release is create `release-please` will re-format the changelog.