### PR TITLE
fix: decode Uint8Array module source from synchronous hooks

### DIFF
--- a/hook.mjs
+++ b/hook.mjs
@@ -84,7 +84,12 @@ export function loadResult(url, result) {
     try {
       const moduleType = result.format === 'module' ? 'esm' :
         result.format === 'commonjs' ? 'cjs' : 'unknown'
-      const transformedCode = transformer.transform(code.toString('utf8'), moduleType)
+      // Node's synchronous hooks (`Module.registerHooks`) deliver `source` as a plain `Uint8Array`,
+      // whereas the async loader delivers a `Buffer`. `Uint8Array.prototype.toString('utf8')` ignores
+      // the encoding and returns comma-joined byte values instead of the decoded text, so decode via
+      // `Buffer` for anything that isn't already a string.
+      const source = typeof code === 'string' ? code : Buffer.from(code).toString('utf8')
+      const transformedCode = transformer.transform(source, moduleType)
       result.source = transformedCode?.code
       result.shortCircuit = true
       if (diagnosticsHook) {

--- a/test/hook-sync.test.mjs
+++ b/test/hook-sync.test.mjs
@@ -202,6 +202,39 @@ test('should default initialization to not crash if not defined', async (t) => {
   assert.deepEqual(result.source, snapshot)
 })
 
+test('should rewrite code when the loader provides source as a Uint8Array (not a Buffer)', async (t) => {
+  const { syncLoaderRewriter } = t.ctx
+  const esmPath = path.join(import.meta.dirname, './example-deps/lib/node_modules/esm-pkg/foo.js')
+  const url = `file://${esmPath}`
+  function resolveFn() {
+    return { url }
+  }
+  // Node's synchronous module hooks (`Module.registerHooks`, Node >= 24.13 / 25.1 / 26) deliver the
+  // module source as a plain `Uint8Array`, unlike the async loader which provides a `Buffer`. A plain
+  // `Uint8Array.prototype.toString('utf8')` ignores the encoding and returns comma-joined byte values
+  // rather than the decoded text, so this is the exact shape that must be handled.
+  function nextLoadBytes() {
+    const buf = readFileSync(esmPath)
+    const source = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    assert.ok(!Buffer.isBuffer(source), 'precondition: source is a plain Uint8Array, not a Buffer')
+    return { format: 'module', source }
+  }
+  function nextLoadString() {
+    return { format: 'module', source: readFileSync(esmPath, 'utf8') }
+  }
+
+  syncLoaderRewriter.resolve('esm-pkg', {}, resolveFn)
+  const fromString = syncLoaderRewriter.load(url, {}, nextLoadString)
+  syncLoaderRewriter.resolve('esm-pkg', {}, resolveFn)
+  const fromBytes = syncLoaderRewriter.load(url, {}, nextLoadBytes)
+
+  assert.equal(fromBytes.format, 'module')
+  assert.equal(fromBytes.shortCircuit, true, 'matching module must be transformed even when source is a Uint8Array')
+  assert.equal(typeof fromBytes.source, 'string')
+  // Byte-source and string-source inputs must produce identical transformed output.
+  assert.equal(fromBytes.source, fromString.source)
+})
+
 test('should rewrite code and call diagnostics hook', async (t) => {
   const { syncLoaderRewriter, snap } = t.ctx
   syncLoaderRewriter.setDiagnosticsHook(({url, moduleName, error}) => {


### PR DESCRIPTION
## Summary

On the **synchronous** module-hooks path (`Module.registerHooks`), `loadResult()` mis-decodes the module source, so matching modules are loaded **untransformed** and no tracing channels are injected — silently. The fix decodes a `Uint8Array` source through `Buffer` so the sync and async paths behave identically.

## Root cause

`loadResult()` decodes the source with:

```js
transformer.transform(code.toString('utf8'), moduleType)
```

The two loader paths deliver `result.source` as **different types**:

- Async loader (`Module.register`) → Node **`Buffer`**
- Sync hooks (`Module.registerHooks`) → plain **`Uint8Array`**

`Buffer.prototype.toString('utf8')` decodes to text. But a plain `Uint8Array` uses `TypedArray.prototype.toString`, which **ignores the encoding argument** and returns the comma-joined decimal byte values. So on the sync path the transformer receives e.g.

```
"118,97,114,32,95,95,100,101,102,..."   // = "var __def..." as decimal bytes
```

instead of

```
"var __defProp = Object.defineProperty;\n..."
```

The transformer can't find the configured functions in that, throws `Failed to find injection points for: [...]`, and the error is swallowed by the **debug-only** `catch`. `result.source`/`result.shortCircuit` are never set, so the module loads unmodified and **no channels are injected** — with no error surfaced.

## Affected runtimes

Anything that routes to the synchronous hooks: **Node ≥ 24.13, Node ≥ 25.1, all Node 26, and Deno ≥ 2.8.** Older Node (which uses the async `Module.register` path) is unaffected, which is why this only shows up on newer runtimes.

## Why it wasn't caught

Every existing `hook-sync` test feeds `source` as a **string** (`readFileSync(path, 'utf8')`), for which `.toString('utf8')` is a no-op. Real Node sync hooks hand the source over as a `Uint8Array`, which no test exercised. The added test reproduces that exact shape (and fails without this change).

## Fix

```js
const source = typeof code === 'string' ? code : Buffer.from(code).toString('utf8')
const transformedCode = transformer.transform(source, moduleType)
```

`Buffer.from()` correctly handles `Buffer`, `Uint8Array`, and `ArrayBuffer`; strings pass straight through. The CJS `Module.prototype._compile` patch in `index.js` is unaffected — `_compile` always receives a string.

## Test

Adds a sync-hook test that delivers `source` as a plain `Uint8Array` (asserting `!Buffer.isBuffer(source)` as a precondition) and checks the module is transformed (`shortCircuit === true`) and produces output identical to the string-source path. It fails on `main` and passes with the fix. Full suite: 28/28.

## Downstream impact

Found while debugging the Sentry JavaScript SDK's orchestrion-based auto-instrumentation, which silently produced **no spans on Node 24.13+/25.1+/26** (and surfaced as integration-test timeouts: the harness waited forever for span envelopes that never arrived). Verified end-to-end that this patch restores instrumentation on Node 24.16. See https://github.com/getsentry/sentry-javascript/pull/21658
